### PR TITLE
Adjusted search mode

### DIFF
--- a/includes/class-image-crate-api.php
+++ b/includes/class-image-crate-api.php
@@ -172,7 +172,7 @@ class Image_Crate_Api {
 		$limit                = $per_page;
 		$mode                 = 'bool'; // options include (any, all, phrase, bool)
 		$offset               = $page;
-		$terms                = sprintf( '(%s)', strtolower( $phrase ) ); // asterisk is needed for wildcard searches on usatoday images
+		$terms                = sprintf( '(%s)', strtolower( $phrase ) );
 
 		// Generate signature
 		$sigBase = "GET&" . rawurlencode( $baseUrl ) . "&"

--- a/includes/class-image-crate-api.php
+++ b/includes/class-image-crate-api.php
@@ -170,9 +170,9 @@ class Image_Crate_Api {
 		$oauthSignatureMethod = "HMAC-SHA1";
 		$oauthVersion         = "1.0";
 		$limit                = $per_page;
-		$mode                 = 'phrase'; // options include (any, all, phrase, bool)
+		$mode                 = 'bool'; // options include (any, all, phrase, bool)
 		$offset               = $page;
-		$terms                = strtolower( $phrase ) . '*'; // asterisk is needed for wildcard searches on usatoday images
+		$terms                = sprintf( '(%s)', strtolower( $phrase ) ); // asterisk is needed for wildcard searches on usatoday images
 
 		// Generate signature
 		$sigBase = "GET&" . rawurlencode( $baseUrl ) . "&"


### PR DESCRIPTION
Alter search mode type for better query results.

The previous search mode was returning sparse results on specific terms. Queries such as "atlanta falcons" were returning minimal results. By changing the mode to "bool" and surrounding the query with parenthesis allows for better results when searching by phrase.